### PR TITLE
Fix Note Tweaker: Override dot color

### DIFF
--- a/Modules/BeatSaberPlus_NoteTweaker/Patches/PColorNoteVisuals.cs
+++ b/Modules/BeatSaberPlus_NoteTweaker/Patches/PColorNoteVisuals.cs
@@ -134,6 +134,18 @@ namespace BeatSaberPlus_NoteTweaker.Patches
                 l_CurrentRenderer.enabled                            = l_DotEnabled;
                 l_CurrentRenderer.gameObject.transform.localScale    = l_CircleScale;
                 l_CurrentRenderer.material.color                     = l_DotColor;
+
+                if (l_DotEnabled)
+                {
+                    m_ComponentsCache.Clear();
+                    l_CurrentRenderer.GetComponents(m_ComponentsCache);
+                    for (int l_MBI = 0; l_MBI < m_ComponentsCache.Count; ++l_MBI)
+                    {
+                        var l_CurrentBlock = m_ComponentsCache[l_MBI];
+                        l_CurrentBlock.materialPropertyBlock.SetColor(_colorId, l_DotColor);
+                        l_CurrentBlock.ApplyChanges();
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
The dot override color was being shown in the preview but had no effect in game.
This seems to fix it, although I don't fully understand the code, not sure if it causes any side effects.

The dot glow intensity slider still doesn't seem to do anything (unless set to 0), but I don't know how to fix it.

See https://discord.com/channels/723117082111246416/1210857445090402314/1210857445090402314