### PR TITLE
fix accuracy dots not showing when dot glow was set as 0%

### DIFF
--- a/Modules/BeatSaberPlus_NoteTweaker/NTConfig.cs
+++ b/Modules/BeatSaberPlus_NoteTweaker/NTConfig.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using UnityEngine;
@@ -20,8 +20,9 @@ namespace BeatSaberPlus_NoteTweaker
             [JsonProperty] internal string Name = "New profile";
 
             [JsonProperty] internal float NotesScale = 0.9f;
-            [JsonProperty] internal bool  NotesShowPrecisonDots = true;
-            [JsonProperty] internal float NotesPrecisonDotsScale = 0.40f;
+            [JsonProperty] internal bool  NotesShowPrecisonDots   = true;
+            [JsonProperty] internal float NotesPrecisonDotsScale  = 0.40f;
+            [JsonProperty] internal float NotesPrecisonDotsOpacity = 1.0f;
 
             [JsonProperty] internal float ArrowsScale = 1.0f;
             [JsonProperty] internal float ArrowsIntensity = 1.0f;

--- a/Modules/BeatSaberPlus_NoteTweaker/Patches/PColorNoteVisuals.cs
+++ b/Modules/BeatSaberPlus_NoteTweaker/Patches/PColorNoteVisuals.cs
@@ -1,4 +1,4 @@
-﻿using CP_SDK.Unity.Extensions;
+using CP_SDK.Unity.Extensions;
 using HarmonyLib;
 using System.Collections.Generic;
 using UnityEngine;
@@ -29,6 +29,7 @@ namespace BeatSaberPlus_NoteTweaker.Patches
         private static Vector3  m_PrecisionCircleScale;
         private static bool     m_OverrideDotColors;
         private static float    m_DotAlpha;
+        private static float    m_PrecisionDotAlpha;
         private static Color    m_LeftCircleColor;
         private static Color    m_RightCircleColor;
         private static Color    m_LeftBlockColor;
@@ -93,14 +94,16 @@ namespace BeatSaberPlus_NoteTweaker.Patches
             if (!m_Enabled)
                 return;
 
-            var l_IsBurstNote   = (bool)__instance.GetComponent<BurstSliderGameNoteController>();
-            var l_CutDirection  = ____noteController.noteData.cutDirection;
-            var l_DotEnabled    = l_CutDirection == NoteCutDirection.Any ? m_CircleEnabled : (m_CircleEnabled && m_CircleForceEnabled);
+            var l_IsBurstNote     = (bool)__instance.GetComponent<BurstSliderGameNoteController>();
+            var l_CutDirection    = ____noteController.noteData.cutDirection;
+            var l_IsPrecisionDot  = l_CutDirection != NoteCutDirection.Any;
+            var l_DotEnabled      = l_IsPrecisionDot ? m_CircleForceEnabled : m_CircleEnabled;
 
             var l_BaseColor = ____colorManager.ColorForType(l_ColorType);
 
-            var l_ArrowColor = ColorU.WithAlpha(m_OverrideArrowColors ? (l_ColorType == ColorType.ColorB ? m_RightArrowColor  : m_LeftArrowColor)  : l_BaseColor, m_ArrowAlpha);
-            var l_DotColor   = ColorU.WithAlpha(m_OverrideDotColors   ? (l_ColorType == ColorType.ColorB ? m_RightCircleColor : m_LeftCircleColor) : l_BaseColor, m_DotAlpha);
+            var l_DotBaseColor = m_OverrideDotColors ? (l_ColorType == ColorType.ColorB ? m_RightCircleColor : m_LeftCircleColor) : l_BaseColor;
+            var l_ArrowColor   = ColorU.WithAlpha(m_OverrideArrowColors ? (l_ColorType == ColorType.ColorB ? m_RightArrowColor  : m_LeftArrowColor)  : l_BaseColor, m_ArrowAlpha);
+            var l_DotColor     = ColorU.WithAlpha(l_DotBaseColor, l_IsPrecisionDot ? m_PrecisionDotAlpha : m_DotAlpha);
 
             if (m_BlockColorsEnabled)
                 l_ArrowColor = ColorU.WithAlpha(l_ColorType == ColorType.ColorA ? m_LeftBlockColor : m_RightBlockColor, 0.6f);
@@ -194,10 +197,11 @@ namespace BeatSaberPlus_NoteTweaker.Patches
         }
         internal static void SetDotColorsFromConfig(NTConfig._Profile p_Profile)
         {
-            m_OverrideDotColors = NTConfig.Instance.Enabled ? p_Profile.DotsOverrideColors  : false;
-            m_DotAlpha          = NTConfig.Instance.Enabled ? p_Profile.DotsIntensity       : 1f;
-            m_LeftCircleColor   = NTConfig.Instance.Enabled ? p_Profile.DotsLColor          : new Color(0.659f, 0.125f, 0.125f, 1.000f);
-            m_RightCircleColor  = NTConfig.Instance.Enabled ? p_Profile.DotsRColor          : new Color(0.125f, 0.392f, 0.659f, 1.000f);
+            m_OverrideDotColors  = NTConfig.Instance.Enabled ? p_Profile.DotsOverrideColors       : false;
+            m_DotAlpha           = NTConfig.Instance.Enabled ? p_Profile.DotsIntensity            : 1f;
+            m_PrecisionDotAlpha  = NTConfig.Instance.Enabled ? p_Profile.NotesPrecisonDotsOpacity : 1f;
+            m_LeftCircleColor    = NTConfig.Instance.Enabled ? p_Profile.DotsLColor               : new Color(0.659f, 0.125f, 0.125f, 1.000f);
+            m_RightCircleColor   = NTConfig.Instance.Enabled ? p_Profile.DotsRColor               : new Color(0.125f, 0.392f, 0.659f, 1.000f);
         }
 
         ////////////////////////////////////////////////////////////////////////////

--- a/Modules/BeatSaberPlus_NoteTweaker/UI/SettingsMainView.cs
+++ b/Modules/BeatSaberPlus_NoteTweaker/UI/SettingsMainView.cs
@@ -1,4 +1,4 @@
-﻿using CP_SDK.UI.Data;
+using CP_SDK.UI.Data;
 using CP_SDK.Unity.Extensions;
 using CP_SDK.XUI;
 using Newtonsoft.Json;
@@ -20,6 +20,7 @@ namespace BeatSaberPlus_NoteTweaker.UI
         private XUISlider           m_NotesTab_Scale                = null;
         private XUIToggle           m_NotesTab_ShowPrecisonDots     = null;
         private XUISlider           m_NotesTab_PrecisionDotsScale   = null;
+        private XUISlider           m_NotesTab_PrecisionDotsOpacity = null;
 
         private XUISlider           m_ArrowsTab_Scale           = null;
         private XUISlider           m_ArrowsTab_Intensity       = null;
@@ -146,7 +147,13 @@ namespace BeatSaberPlus_NoteTweaker.UI
                     XUISlider.Make()
                         .SetMinValue(0.2f).SetMaxValue(1.5f).SetIncrements(0.01f).SetFormatter(CP_SDK.UI.ValueFormatters.Percentage)
                         .OnValueChanged((_) => OnSettingChanged())
-                        .Bind(ref m_NotesTab_PrecisionDotsScale)
+                        .Bind(ref m_NotesTab_PrecisionDotsScale),
+
+                    XUIText.Make("Precision dot opacity"),
+                    XUISlider.Make()
+                        .SetMinValue(0.0f).SetMaxValue(1.0f).SetIncrements(0.01f).SetFormatter(CP_SDK.UI.ValueFormatters.Percentage)
+                        .OnValueChanged((_) => OnSettingChanged())
+                        .Bind(ref m_NotesTab_PrecisionDotsOpacity)
                 )
                 .SetWidth(80.0f)
                 .SetPadding(0),
@@ -330,9 +337,10 @@ namespace BeatSaberPlus_NoteTweaker.UI
             var l_Profile = NTConfig.Instance.GetActiveProfile();
 
             #region Notes Tab
-            l_Profile.NotesScale                = m_NotesTab_Scale.Element.GetValue();
-            l_Profile.NotesShowPrecisonDots     = m_NotesTab_ShowPrecisonDots.Element.GetValue();
-            l_Profile.NotesPrecisonDotsScale    = m_NotesTab_PrecisionDotsScale.Element.GetValue();
+            l_Profile.NotesScale                 = m_NotesTab_Scale.Element.GetValue();
+            l_Profile.NotesShowPrecisonDots      = m_NotesTab_ShowPrecisonDots.Element.GetValue();
+            l_Profile.NotesPrecisonDotsScale     = m_NotesTab_PrecisionDotsScale.Element.GetValue();
+            l_Profile.NotesPrecisonDotsOpacity   = m_NotesTab_PrecisionDotsOpacity.Element.GetValue();
             #endregion
 
             #region Arrows Tab
@@ -390,6 +398,7 @@ namespace BeatSaberPlus_NoteTweaker.UI
             m_NotesTab_Scale                .SetValue(l_Profile.NotesScale);
             m_NotesTab_ShowPrecisonDots     .SetValue(l_Profile.NotesShowPrecisonDots);
             m_NotesTab_PrecisionDotsScale   .SetValue(l_Profile.NotesPrecisonDotsScale);
+            m_NotesTab_PrecisionDotsOpacity .SetValue(l_Profile.NotesPrecisonDotsOpacity);
             #endregion
 
             #region Arrows Tab

--- a/Modules/BeatSaberPlus_NoteTweaker/UI/SettingsRightView.cs
+++ b/Modules/BeatSaberPlus_NoteTweaker/UI/SettingsRightView.cs
@@ -1,4 +1,4 @@
-﻿using CP_SDK.Unity.Extensions;
+using CP_SDK.Unity.Extensions;
 using CP_SDK.XUI;
 using IPA.Utilities;
 using System.Linq;
@@ -198,10 +198,10 @@ namespace BeatSaberPlus_NoteTweaker.UI
             var l_DotLColor = l_Profile.DotsOverrideColors ? l_Profile.DotsLColor : ColorU.WithAlpha(l_LeftColor,  l_Profile.DotsLColor.a);
             var l_DotRColor = l_Profile.DotsOverrideColors ? l_Profile.DotsRColor : ColorU.WithAlpha(l_RightColor, l_Profile.DotsRColor.a);
 
-            PatchCircle(m_CustomPreviewTL, l_Profile.NotesPrecisonDotsScale,    l_DotLColor,   l_Profile.NotesShowPrecisonDots);
-            PatchCircle(m_CustomPreviewTR, l_Profile.NotesPrecisonDotsScale,    l_DotRColor,   l_Profile.NotesShowPrecisonDots);
-            PatchCircle(m_CustomPreviewDL, l_Profile.DotsScale,                 l_DotLColor,   true);
-            PatchCircle(m_CustomPreviewDR, l_Profile.DotsScale,                 l_DotRColor,   true);
+            PatchCircle(m_CustomPreviewTL, l_Profile.NotesPrecisonDotsScale,    ColorU.WithAlpha(l_DotLColor, l_Profile.NotesPrecisonDotsOpacity), l_Profile.NotesShowPrecisonDots);
+            PatchCircle(m_CustomPreviewTR, l_Profile.NotesPrecisonDotsScale,    ColorU.WithAlpha(l_DotRColor, l_Profile.NotesPrecisonDotsOpacity), l_Profile.NotesShowPrecisonDots);
+            PatchCircle(m_CustomPreviewDL, l_Profile.DotsScale,                 ColorU.WithAlpha(l_DotLColor, l_Profile.DotsIntensity),            true);
+            PatchCircle(m_CustomPreviewDR, l_Profile.DotsScale,                 ColorU.WithAlpha(l_DotRColor, l_Profile.DotsIntensity),            true);
 
             PatchBomb(m_CustomPreviewBomb, l_Profile.BombsOverrideColor ? l_Profile.BombsColor : new Color(0.251f, 0.251f, 0.251f, 1f));
 


### PR DESCRIPTION
title, pretty much.
Also added a new settings slider to keep the old behaviour in case someone would want it