### PR TITLE
ChatRequest small fixes

### DIFF
--- a/Modules/BeatSaberPlus_ChatRequest/CRConfig.cs
+++ b/Modules/BeatSaberPlus_ChatRequest/CRConfig.cs
@@ -166,7 +166,7 @@ namespace BeatSaberPlus_ChatRequest
                            internal EPermission RemoveCommandPermissions    = EPermission.Moderators;
             [JsonProperty] internal bool        RemoveCommandEnabled        = true;
             [JsonProperty] internal string      RemoveCommand               = "remove";
-            [JsonProperty] internal string      RemoveCommand_OK            = $"@$UserName (bsr $BSRKey) $SongName / $LevelAuthorName request by @RequesterName is removed from queue!";
+            [JsonProperty] internal string      RemoveCommand_OK            = $"@$UserName (bsr $BSRKey) $SongName / $LevelAuthorName request by @$RequesterName is removed from queue!";
             [JsonProperty] internal string      RemoveCommand_NotFound      = $"@$UserName No song in queue found with the key or username \"$Subject\"!";
 
             [JsonProperty, JsonConverter(typeof(StringEnumConverter))]

--- a/Modules/BeatSaberPlus_ChatRequest/CRConfig.cs
+++ b/Modules/BeatSaberPlus_ChatRequest/CRConfig.cs
@@ -279,6 +279,9 @@ namespace BeatSaberPlus_ChatRequest
 
             if (Commands != null && !Commands.LinkCommand_CurrentSong.Contains("$SongLink"))
                 Commands.LinkCommand_CurrentSong += " $SongLink";
+
+            if (Commands != null && Commands.RemoveCommand_OK.Contains("@RequesterName"))
+                Commands.RemoveCommand_OK = Commands.RemoveCommand_OK.Replace("@RequesterName", "@$RequesterName");
         }
     }
 }

--- a/Modules/BeatSaberPlus_ChatRequest/ChatRequest.cs
+++ b/Modules/BeatSaberPlus_ChatRequest/ChatRequest.cs
@@ -231,6 +231,8 @@ namespace BeatSaberPlus_ChatRequest
                         else
                             m_LastPlayingLevelResponse = $"{l_CurrentMap.songName} by {l_Mapper}";
 
+                        m_LastPlayingLevelResponseLink = "";
+
                         if (CP_SDK_BS.Game.Levels.LevelID_IsCustom(l_CurrentMap.levelID) && CP_SDK_BS.Game.Levels.TryGetHashFromLevelID(l_CurrentMap.levelID, out var l_Hash))
                         {
                             var l_CachedEntry = null as Models.SongEntry;

--- a/Modules/BeatSaberPlus_ChatRequest/ChatRequest_Logic.cs
+++ b/Modules/BeatSaberPlus_ChatRequest/ChatRequest_Logic.cs
@@ -576,6 +576,8 @@ namespace BeatSaberPlus_ChatRequest
 
                 if (UI.ManagerLeftView.CanBeUpdated)
                     UI.ManagerLeftView.Instance.UpdateQueueStatus();
+                if (UI.ManagerMainView.CanBeUpdated)
+                    UI.ManagerMainView.Instance.RebuiltTitle();
             });
         }
         /// <summary>

--- a/Modules/BeatSaberPlus_ChatRequest/ChatRequest_Logic.cs
+++ b/Modules/BeatSaberPlus_ChatRequest/ChatRequest_Logic.cs
@@ -91,13 +91,6 @@ namespace BeatSaberPlus_ChatRequest
                     l_ForceAllow = true;
             }
 
-            /// Check if already requested
-            if (!asModAdd && m_RequestedThisSessionID.Contains(bsrKey.ToLower()))
-            {
-                callback?.Invoke(new Models.AddToQueueResult(Models.EAddToQueueResult.AlreadyRequestedThisSession, bsrKey));
-                return;
-            }
-
             /// Check if allow listed or blocklisted
             if (!asModAdd && !l_ForceAllow)
             {
@@ -126,6 +119,13 @@ namespace BeatSaberPlus_ChatRequest
 
                 if (requester != null)
                     l_RateLimit.CurrentRequestCount = SongQueue.Where(x => x.RequesterName == requester.UserName).Count();
+            }
+
+            /// Check if already requested
+            if (!asModAdd && m_RequestedThisSessionID.Contains(bsrKey.ToLower()))
+            {
+                callback?.Invoke(new Models.AddToQueueResult(Models.EAddToQueueResult.AlreadyRequestedThisSession, bsrKey));
+                return;
             }
 
             /// Handle limits and title prefix
@@ -203,13 +203,6 @@ namespace BeatSaberPlus_ChatRequest
                     l_ForceAllow = true;
             }
 
-            /// Check if already requested
-            if (!asModAdd && m_RequestedThisSessionHash.Contains(l_LevelHash))
-            {
-                callback?.Invoke(new Models.AddToQueueResult(Models.EAddToQueueResult.AlreadyRequestedThisSession, l_LevelHash));
-                return;
-            }
-
             /// Check if allow listed or blocklisted
             if (!asModAdd && !l_ForceAllow)
             {
@@ -238,6 +231,13 @@ namespace BeatSaberPlus_ChatRequest
 
                 if (requester != null)
                     l_RateLimit.CurrentRequestCount = SongQueue.Where(x => x.RequesterName == requester.UserName).Count();
+            }
+
+            /// Check if already requested
+            if (!asModAdd && m_RequestedThisSessionHash.Contains(l_LevelHash))
+            {
+                callback?.Invoke(new Models.AddToQueueResult(Models.EAddToQueueResult.AlreadyRequestedThisSession, l_LevelHash));
+                return;
             }
 
             /// Handle limits and title prefix


### PR DESCRIPTION
A few small bug fixes for the chat request module. There are separate commits but I put them on one branch.

- The default `RemoveCommand_OK` text had `@RequesterName` instead of `@$RequesterName`
- Using the `!link` command during a WIP or OST map would send the url of the previous map. Set it to empty string instead.
- Update the "queue is open/closed" text in the center panel when opening/closing queue.
- Moved the check for "already requested this session" below the check for "already in queue". The "already in queue" message is more useful, even though locking the queue is more expensive, most requests will have to do both checks anyway.